### PR TITLE
introduce DataStore classes

### DIFF
--- a/lib/simple_map_reduce.rb
+++ b/lib/simple_map_reduce.rb
@@ -19,6 +19,9 @@ end
 
 require 'simple_map_reduce/version'
 require 'simple_map_reduce/s3_client'
+require 'simple_map_reduce/data_stores/default_data_store'
+require 'simple_map_reduce/data_stores/remote_data_store'
+require 'simple_map_reduce/data_store_factory'
 require 'simple_map_reduce/driver/config'
 require 'simple_map_reduce/driver/job'
 require 'simple_map_reduce/server/confg'

--- a/lib/simple_map_reduce/data_store_factory.rb
+++ b/lib/simple_map_reduce/data_store_factory.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module SimpleMapReduce
+  class DataStoreFactory
+    TYPES = %w(default remote).freeze
+
+    class << self
+      def create(data_store_type, options = {})
+        unless TYPES.include?(data_store_type)
+          raise ArgumentError, "Unsupported data_store_type: `#{data_store_type}`"
+        end
+
+        case data_store_type
+        when 'default'
+          SimpleMapReduce::DataStores::DefaultDataStore.new(options)
+        when 'remote'
+          options[:job_tracker_url] = SimpleMapReduce.job_tracker_url
+          SimpleMapReduce::DataStores::RemoteDataStore.new(options)
+        end
+      end
+    end
+  end
+end

--- a/lib/simple_map_reduce/data_stores/default_data_store.rb
+++ b/lib/simple_map_reduce/data_stores/default_data_store.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SimpleMapReduce
+  module DataStores
+    class DefaultDataStore
+      def initialize(_options)
+        # do nothing
+      end
+
+      def save_state(_evnet)
+        # do nothing
+      end
+    end
+  end
+end

--- a/lib/simple_map_reduce/data_stores/remote_data_store.rb
+++ b/lib/simple_map_reduce/data_stores/remote_data_store.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module SimpleMapReduce
+  module DataStores
+    class RemoteDataStore
+      def initialize(options)
+        @resource_name = options[:resource_name]
+        @resource_id = options[:resource_id]
+        @job_tracker_url = options[:job_tracker_url]
+      end
+
+      def save_state(event)
+        http_client.put do |request|
+          request.url("/#{@resource_name}/#{@resource_id}")
+          request.body = { event: event }.to_json
+        end
+      end
+
+      private
+
+      HTTP_JSON_HEADER = {
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/json'
+      }.freeze
+
+      def http_client
+        @http_client ||= ::Faraday.new(
+          url: @job_tracker_url,
+          headers: HTTP_JSON_HEADER,
+          request: {
+            open_timeout: 10,
+            timeout: 15
+          }
+        ) do |faraday|
+          faraday.response :logger
+          faraday.response :raise_error
+          faraday.adapter  Faraday.default_adapter
+        end
+      end
+    end
+  end
+end

--- a/lib/simple_map_reduce/worker/register_map_task_worker.rb
+++ b/lib/simple_map_reduce/worker/register_map_task_worker.rb
@@ -11,9 +11,6 @@ module SimpleMapReduce
           request.body = job.serialize
         end
         logger.debug(response.body)
-
-        job.map_worker.work!
-        job.start!
       rescue => e
         logger.error(e.inspect)
         logger.error(e.backtrace.take(50))

--- a/lib/simple_map_reduce/worker/run_reduce_task_worker.rb
+++ b/lib/simple_map_reduce/worker/run_reduce_task_worker.rb
@@ -3,7 +3,7 @@
 module SimpleMapReduce
   module Worker
     class RunReduceTaskWorker
-      def perform(task, reduce_worker_id)
+      def perform(task, reduce_worker)
         task_wrapper_class_name = "TaskWrapper#{task.id.delete('-')}"
         self.class.class_eval("class #{task_wrapper_class_name}; end", 'Task Wrapper Class')
         task_wrapper_class = self.class.const_get(task_wrapper_class_name)
@@ -54,11 +54,7 @@ module SimpleMapReduce
         end
 
         begin
-          response = http_client(SimpleMapReduce.job_tracker_url).put do |request|
-            request.url("/workers/#{reduce_worker_id}")
-            request.body = { event: 'ready' }.to_json
-          end
-          logger.debug(response.body)
+          reduce_worker.ready!
         rescue => notify_error
           logger.fatal(notify_error.inspect)
           logger.fatal(notify_error.backtrace.take(50))


### PR DESCRIPTION
issue https://github.com/serihiro/simple_map_reduce/issues/2

# What will this PR change?
- introduce `DataStore` classes
    - `DefaultDataStore`
    - `RemoteDataStore`
- Delegate `save_state` method (which is called as a state transition callback) to the instance of DataStore class in each Model calsses

# TODO
- [x] Support data store at `Job`
- [x] Support data store at `Worker`