### PR TITLE
create different tempfile references

### DIFF
--- a/lib/simple_map_reduce/worker/run_map_task_worker.rb
+++ b/lib/simple_map_reduce/worker/run_map_task_worker.rb
@@ -113,7 +113,8 @@ module SimpleMapReduce
         workers_count = workers.count
         raise 'No workers' unless workers_count > 0
 
-        shuffled_local_outputs = Array.new(workers_count, Tempfile.new)
+        shuffled_local_outputs = Array.new(workers_count)
+        shuffled_local_outputs.each_with_index { |_, i| shuffled_local_outputs[i] = Tempfile.new }
         local_output_cache.each_line(rs: "\n") do |raw_line|
           output = JSON.parse(raw_line, symbolize_names: true)
           partition_id = output[:key].hash % workers_count


### PR DESCRIPTION
# What will this PR change ?
Fix a shameful bug after three years.

```bash
docker run ruby:2.7.4-alpine ruby -e 'require "tempfile"; puts(Array.new(3, Tempfile.new))'
#<File:0x00007ffb49004910>
#<File:0x00007ffb49004910>
#<File:0x00007ffb49004910>
```