### PR TITLE
Improve Worker update and add specs

### DIFF
--- a/lib/simple_map_reduce/server/job_tracker.rb
+++ b/lib/simple_map_reduce/server/job_tracker.rb
@@ -154,6 +154,7 @@ module SimpleMapReduce
           (params[:worker_size].to_i.zero? ? 1 : params[:worker_size].to_i.abs),
           MAX_WORKER_RESERVABLE_SIZE
         ].min
+        reserved_workers = []
         begin
           reserved_workers = self.class.fetch_available_workers(worker_size)
           json(succeeded: true, reserved_workers: reserved_workers.map(&:dump))

--- a/lib/simple_map_reduce/server/worker.rb
+++ b/lib/simple_map_reduce/server/worker.rb
@@ -70,7 +70,7 @@ module SimpleMapReduce
       # @options attributes [String] event
       def update!(attrs = {})
         # Handle both hash and keyword arguments
-        attrs = attrs.is_a?(Hash) ? attrs : { url: nil, event: nil }
+        attrs = attrs.is_a?(Hash) ? attrs : { event: attrs }
         url = attrs[:url]
         event = attrs[:event]
 

--- a/spec/server/worker_spec.rb
+++ b/spec/server/worker_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe SimpleMapReduce::Server::Worker do
+  let(:worker) { build(:worker) }
+
+  describe '#update!' do
+    context 'when called with an event symbol' do
+      it 'updates the state accordingly' do
+        expect(worker.state).to eq(:ready)
+        worker.update!(:reserve)
+        expect(worker.state).to eq(:reserved)
+      end
+    end
+
+    context 'when called with a hash of attributes' do
+      it 'updates the state based on the :event key' do
+        worker.update!(event: :reserve)
+        worker.update!(event: :work)
+        expect(worker.state).to eq(:working)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- avoid NameError in `/workers/reserve` by initializing `reserved_workers`
- allow `Worker#update!` to accept an event argument directly
- add specs covering `Worker#update!` behaviour

## Testing
- `bundle exec rake spec`


------
https://chatgpt.com/codex/tasks/task_e_684110c9f4208329940948d8ad88efe8