### PR TITLE
Update Sinatra requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ So I decided to create an experimental implementation, and keep adding new featu
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` (or `bundle install`) to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/lib/simple_map_reduce/server/job_tracker.rb
+++ b/lib/simple_map_reduce/server/job_tracker.rb
@@ -13,6 +13,9 @@ module SimpleMapReduce
         # TODO: be configurable
         MAX_WORKER_RESERVABLE_SIZE = 5
       end
+      configure :test do
+        disable :protection
+      end
       configure :development do
         register Sinatra::Reloader
       end

--- a/lib/simple_map_reduce/server/job_worker.rb
+++ b/lib/simple_map_reduce/server/job_worker.rb
@@ -11,6 +11,9 @@ module SimpleMapReduce
       configure do
         use Rack::Lock
       end
+      configure :test do
+        disable :protection
+      end
       configure :development do
         register Sinatra::Reloader
       end

--- a/simple_map_reduce.gemspec
+++ b/simple_map_reduce.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'faraday', '>= 0.13', '< 2.8'
   spec.add_runtime_dependency 'msgpack', '>= 1.2', '< 1.5'
   spec.add_runtime_dependency 'rasteira', '~> 0.1.0'
-  spec.add_runtime_dependency 'sinatra', '~> 3.0'
-  spec.add_runtime_dependency 'sinatra-contrib', '~> 3.0'
+  spec.add_runtime_dependency 'sinatra', '~> 4.1'
+  spec.add_runtime_dependency 'sinatra-contrib', '~> 4.1'
   spec.add_runtime_dependency 'thor', '>= 0.20', '< 1.3'
 end

--- a/spec/server/worker_spec.rb
+++ b/spec/server/worker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe SimpleMapReduce::Server::Worker do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@
 require 'bundler/setup'
 require 'simple_map_reduce'
 require 'rack/test'
+Rack::Test.send(:remove_const, :DEFAULT_HOST)
+Rack::Test::DEFAULT_HOST = 'localhost'
 require 'factory_bot'
 
 ENV['RACK_ENV'] = 'test'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,7 @@
 require 'bundler/setup'
 require 'simple_map_reduce'
 require 'rack/test'
-Rack::Test.send(:remove_const, :DEFAULT_HOST)
-Rack::Test::DEFAULT_HOST = 'localhost'
+Rack::Test.const_set(:DEFAULT_HOST, 'localhost')
 require 'factory_bot'
 
 ENV['RACK_ENV'] = 'test'


### PR DESCRIPTION
## What will this PR change ?
- require Sinatra 4.1+ in the gemspec
- disable Rack protection in tests
- set Rack::Test default host
- clarify setup docs


------
https://chatgpt.com/codex/tasks/task_e_684119e5df048329aef06c3f2ebd59a7